### PR TITLE
Updating symlink target to be the basename of the specified folder

### DIFF
--- a/src/symlink.js
+++ b/src/symlink.js
@@ -35,7 +35,7 @@ const askToOverwrite = (targetExists, folder) => {
 
 // Symlink a folder
 const createFolder = (folder, serverless) => {
-  const target = path.join(process.cwd(), folder.replace(/..\//g, ''));
+  const target = path.join(process.cwd(), path.basename(folder));
 
   // Check if folder/file with symlink name already exists in top level
   return askToOverwrite(exists(target) ? [target] : [], folder)


### PR DESCRIPTION
Currently, the plugin supports folders that looks like `../../../<name>`, but if the folder needed to include is under a subfolder it won't work.

For example, if the folder to include is `../service1/utils/` the created symlink target will be `service1utils`.

To fix that, the basename of given folder should be used (the behavior for paths as supported before won't change).