### PR TITLE
Symlink folder level support, Serverless Framework v3 logging

### DIFF
--- a/src/symlink.js
+++ b/src/symlink.js
@@ -36,7 +36,7 @@ const askToOverwrite = (targetExists, folder) => {
 
 // Build symlink path
 const symlinkTarget = folder => {
-  return path.join(process.cwd(), folder.replace(/.*\//, ''));
+  return path.join(process.cwd(), path.basename(folder));
 };
 
 // Symlink a folder


### PR DESCRIPTION
- Symlink target regex fix for multi-level packages e.g. `../common/mypackage` correctly symlinks to `mypackage`
- Serverless Framework v3 logging
- Cleanup on package finalize, now works with both `sls package` and `sls deploy`